### PR TITLE
Fix the NUL chars filling the html outputs

### DIFF
--- a/Support/tmvc/lib/application_controller.rb
+++ b/Support/tmvc/lib/application_controller.rb
@@ -65,7 +65,7 @@ class ApplicationController
     start_layout
     Object::STDOUT << @output_buffer.string
     Object::flush
-    @output_buffer.truncate(0)
+    @output_buffer.string = ""
   end
   
   def start_layout


### PR DESCRIPTION
`@output_buffer.truncate(0)` replace every bytes in the buffer with \000 each time the flush method is called, which is a lot. E.g. It makes the log output 30 times bigger than necessary. 
Replace it with `@output_buffer.string = ""`.

See [this thread](http://lists.macromates.com/textmate-dev/2012-September/014800.html) on the mailing list.
