### PR TITLE
Add .gitmodules to fileTypes

### DIFF
--- a/Syntaxes/Git Config.tmLanguage
+++ b/Syntaxes/Git Config.tmLanguage
@@ -7,6 +7,7 @@
 		<string>.git/config</string>
 		<string>.gitconfig</string>
 		<string>etc/gitconfig</string>
+		<string>.gitmodules</string>
 	</array>
 	<key>name</key>
 	<string>Git Config</string>


### PR DESCRIPTION
This file contains submodules for the repository and its format is the same as the standard git config file.
