### PR TITLE
Update git-config syntax for double quotes.

### DIFF
--- a/Syntaxes/Git Config.tmLanguage
+++ b/Syntaxes/Git Config.tmLanguage
@@ -5,6 +5,7 @@
 	<key>fileTypes</key>
 	<array>
 		<string>.git/config</string>
+		<string>git/config</string>
 		<string>.gitconfig</string>
 		<string>etc/gitconfig</string>
 		<string>.gitmodules</string>


### PR DESCRIPTION
The gitconfig syntax improperly highlights escaped double quotes. Escaping quotes is sometimes necessary (as in mergetool.cmd and others), but when it's done, the highlighting gets borked for the rest of the file.

![gitconfig-syntax-bad](https://f.cloud.github.com/assets/66879/1651913/5f385fe4-5af8-11e3-88b1-697225401fee.png)

With the changes in ca2c590 this is no longer the case. Also notice the properly highlighted "upstream" in both images (what the regex is specifically trying to capture).

![gitconfig-syntax-good](https://f.cloud.github.com/assets/66879/1651914/618d3c42-5af8-11e3-882c-0591416e854f.png)

Commit ca2c590 isn't necessarily relevant to this fix, but per http://git-scm.com/docs/git-config#FILES is an acceptable file path.
