### PR TITLE
Correctly determine working copy root when inside submodule.

### DIFF
--- a/Commands/Compare Branches.tmCommand
+++ b/Commands/Compare Branches.tmCommand
@@ -11,7 +11,6 @@ require ENV['TM_BUNDLE_SUPPORT'] + '/environment.rb'
 require ENV['TM_SUPPORT_PATH'] + '/lib/osx/plist'
 
 git = Git.new
-path = File.expand_path('..', git.git_dir(git.paths.first))
 
 branches   = git.branch.list(:all)
 parameters = { "branches" =&gt; branches.map { |e| { "name" =&gt; e[:name] } } }

--- a/Support/lib/git.rb
+++ b/Support/lib/git.rb
@@ -77,7 +77,11 @@ module SCM
     
     # The absolute path to working copy
     def path
-      @path ||= File.expand_path('..', git_dir(paths.first))
+      @path ||= %x{
+        cd #{e_sh dir_part(paths.first)}
+        #{git} rev-parse --show-toplevel;
+        cd - > /dev/null;
+      }.chomp
     end
     
     def root


### PR DESCRIPTION
This fixes error messages like "fatal: '/path/to/file' is outside repository" when using the bundle with git submodules.

`Git.path` assumed that the git dir would always be located directly below the working copy root. However, this is not (no longer?) true when working with submodules: The git dir of a submodule is nested inside the parent project’s git dir.

Using `git rev-parse --show-toplevel` (available since Git 1.7.0) figures this out correctly, even for submodules.

Similar incorrect code existed in `Compare Branches.tmCommand`. This was dead code however (`path` not being used anywhere afterwards), so I removed the line there completely.
