### PR TITLE
Only show output window after commit window is closed

### DIFF
--- a/Support/app/controllers/commit_controller.rb
+++ b/Support/app/controllers/commit_controller.rb
@@ -32,16 +32,16 @@ class CommitController < ApplicationController
 
   protected
     def run_partial_commit
-      puts "<h2>#{commit_worker.title}</h2>"
-      flush
       result = commit_worker.run
       render "_commit_result", :locals => result if result
     rescue PartialCommitWorker::NotOnBranchException
       render "not_on_a_branch"
       false
     rescue PartialCommitWorker::NothingToCommitException
+      puts "<h2>#{commit_worker.title}</h2>"
       puts(git.clean_directory? ? "Working directory is clean (nothing to commit)" : "No changes to commit within the current scope. (Try selecting the root folder in the project drawer?)")
     rescue PartialCommitWorker::CommitCanceledException
+      puts "<h2>#{commit_worker.title}</h2>"
       puts "<strong>Canceled</strong>"
     end
 


### PR DESCRIPTION
This change was mentioned in the following pull request textmate/textmate#1210. Changing the original behavior of the commit commands seems to be easier than initially thought and only required removal of a couple of lines  in `commit_controller.rb` that sent output to stdout before calling `PartialCommitWindow`.
