### PR TITLE
Remove leading whitespace from „Clear Stash…“

### DIFF
--- a/Commands/Clear Stash.tmCommand
+++ b/Commands/Clear Stash.tmCommand
@@ -14,7 +14,7 @@ dispatch :controller =&gt; "stash", :action =&gt; "clear"
 	<key>inputFormat</key>
 	<string>text</string>
 	<key>name</key>
-	<string> Clear Stash…</string>
+	<string>Clear Stash…</string>
 	<key>outputCaret</key>
 	<string>afterOutput</string>
 	<key>outputFormat</key>


### PR DESCRIPTION
Hi,

just spotted a “typo” in the git menu. This commit should fix it.

Kind regards,
  René
