### PR TITLE
fix "setAttribute" bug in git log

### DIFF
--- a/Support/resource/toggle.js
+++ b/Support/resource/toggle.js
@@ -16,7 +16,7 @@ function toggle_diff(dom_id) {
   e = $(dom_id)
   if (! e.readAttribute("loaded")) {
     e.update(dispatch({controller: 'diff', action: 'diff', revision: e.readAttribute("rev"), git_path: e.readAttribute("git_path"), path: (e.readAttribute("path") || ""), layout: false}))
-    e.setAttribute("loaded");
+    e.setAttribute("loaded", "");
   }
   
   set_togglable_visibility( dom_id, ! e.visible() );


### PR DESCRIPTION
With the latest Mac OS X update I noticed an error being thrown when I try to expand code blocks in the "git log" ui. This fixes the problem