### PR TITLE
Make `git blame` always use 8 digit refs

### DIFF
--- a/Support/lib/git.rb
+++ b/Support/lib/git.rb
@@ -309,7 +309,7 @@ module SCM
 
     def annotate(file_path, revision = nil)
       file = make_local_path(file_path)
-      args = []
+      args = ["--abbrev=7"]
       args += ["--follow", revision, "--"] unless revision.nil? || revision.empty?
       args << file
       output = command("blame", *args)

--- a/Support/spec/controllers/annotate_controller_spec.rb
+++ b/Support/spec/controllers/annotate_controller_spec.rb
@@ -9,7 +9,7 @@ describe AnnotateController do
   describe "when annotating" do
     before(:all) do
       ENV["TM_SELECTION"] = "1"
-      Git.command_response["blame", "file.rb"] = fixture_file("blame.txt")
+      Git.command_response["blame", "--abbrev=7", "file.rb"] = fixture_file("blame.txt")
       Git.command_response["log", "--date=default", "--format=medium", "--follow", "--name-only", "file.rb"] = fixture_file("log_with_diffs.txt")
       @output = capture_output do 
         dispatch(:controller => "annotate", :file_path => "file.rb")


### PR DESCRIPTION
Because `Scm::Git#short_rev` (as well as `ApplicationHelper#short_rev`) always produce 8 digit refs, we need the output of `git blame` to use the same length, otherwise clicking on a (short) revision in the blame window fails to select the appropriate revision from the select at the top. Fixes https://github.com/textmate/git.tmbundle/issues/46

Note that we have to specify `abbrev=7` to actually get 8 digit revisions (see man page excerpt below).

Long explanation: In some cases / repositories, `git blame` seems to use longer refs by default. I’m not sure why, as the man page (git 2.13.2) explicitly states that the default is 8 (7+1) digits:

```
--abbrev=<n>
    Instead of using the default 7+1 hexadecimal digits as the abbreviated object name, 
    use <n>+1 digits. Note that 1 column is used for a caret to mark the boundary commit.
```

I suspect that this description is incorrect and that the default value is instead taken from `core.abbrev`. The man page for git-config says about this setting:

> If unspecified or set to "auto", an appropriate value is computed based on the approximate number of packed objects in your repository, which hopefully is enough for abbreviated object names to stay unique for some time.
