### PR TITLE
Fixed broken Git Rebase Message syntax for x/exec

### DIFF
--- a/Syntaxes/Git Rebase Message.tmLanguage
+++ b/Syntaxes/Git Rebase Message.tmLanguage
@@ -44,7 +44,26 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^\s*(pick|p|reword|r|edit|e|squash|s|fixup|f|exec|x|drop|d)\s+([0-9a-f]+)\s+(.*)$</string>
+			<string>^\s*(pick|p|reword|r|edit|e|squash|s|fixup|f|drop|d)\s+([0-9a-f]+)\s+(.*)$</string>
+			<key>name</key>
+			<string>meta.commit-command.git-rebase</string>
+		</dict>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>support.function.git-rebase</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>markup.raw.inline.git-rebase</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>^\s*(exec|x)\s+(.*)$</string>
 			<key>name</key>
 			<string>meta.commit-command.git-rebase</string>
 		</dict>


### PR DESCRIPTION
The syntax highlighting for the git rebase message syntax for running commands (by starting a line with `x` or `exec`) wasn't working because it was expecting the initial `x`/`exec` to be followed by a commit SHA— in the form of “«command» «sha» «message»”.  That's the correct syntax stipulations for all the other commands, but not for `x`/`exec`.

Fixed by adding a second `meta.commit-command.git-rebase` pattern that matches only the `x`/`exec` and captures all the text that follows it (skipping the SHA matching).  Removed `x`/`exec`-matching from the first pattern.

Also, changed the rest-of-line captured text's scope identifier from `meta.commit-message.git-rebase` (since it's not at all a commit message for the `x`/`exec` command) to `markup.raw.inline.git-rebase` (which seems to be an appropriate way to get generic code formatting for this).  _Note: I tried to get this capture to render as `source.shell` but couldn't get that magic to work the same way they do in, for example, HTML files with embedded CSS/JS.  Sorry; I'm not very good at TM grammars._