### PR TITLE
Add support for `break` command in `git rebase`

### DIFF
--- a/Syntaxes/Git Rebase Message.tmLanguage
+++ b/Syntaxes/Git Rebase Message.tmLanguage
@@ -82,7 +82,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^\s*(break|b)\s+$</string>
+			<string>^\s*(break|b)\s*$</string>
 			<key>name</key>
 			<string>meta.commit-command.git-rebase</string>
 		</dict>

--- a/Syntaxes/Git Rebase Message.tmLanguage
+++ b/Syntaxes/Git Rebase Message.tmLanguage
@@ -72,6 +72,20 @@
 			<key>name</key>
 			<string>meta.commit-command.git-rebase</string>
 		</dict>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>support.function.git-rebase</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>^\s*(break|b)\s+$</string>
+			<key>name</key>
+			<string>meta.commit-command.git-rebase</string>
+		</dict>
 	</array>
 	<key>scopeName</key>
 	<string>text.git-rebase</string>


### PR DESCRIPTION
The `break` command was added to `git rebase`'s list of available actions [in Git v2.20](https://github.com/git/git/blob/v2.20.0/Documentation/RelNotes/2.20.0.txt#L143-L145).

Thanks to @capnslipp for PR #50, which helped me figure out what I should change to add support for the new command.